### PR TITLE
Consistent line endings everywhere

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"files.eol": "\n"
 }


### PR DESCRIPTION
The lack of `gitattributes` screws the line endings on the standard Windows git configuration (`autoclrf`).