### PR TITLE
Remove react-hot-loader from production bundle

### DIFF
--- a/src/components/react-hot-loader/index.tsx
+++ b/src/components/react-hot-loader/index.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default process.env.NODE_ENV === "development"
+	? require("react-hot-loader").AppContainer
+	: ({ children }: { children: React.ReactChildren }) => React.Children.only(children);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
 import { I18nextProvider } from "react-i18next";
-import { AppContainer } from "react-hot-loader";
 
 import i18n from "common/i18n";
+import ReactHotLoader from "components/react-hot-loader";
 import configureStore from "store/configureStore";
 import Router from "router";
 
@@ -19,13 +19,13 @@ const mountElement = document.getElementById("mount");
 
 function renderRoot() {
 	render(
-		<AppContainer>
+		<ReactHotLoader>
 			<I18nextProvider i18n={i18n}>
 				<Provider store={store}>
 					<Router history={history} />
 				</Provider>
 			</I18nextProvider>
-		</AppContainer>,
+		</ReactHotLoader>,
 		mountElement
 	);
 }


### PR DESCRIPTION
Since we imported it directly it wasn't completely eliminated from the production bundle. It's only ~2.5k so it's not a huge win but why not save every byte we can.