### PR TITLE
Code cleanup

### DIFF
--- a/src/common/loadable.ts
+++ b/src/common/loadable.ts
@@ -1,6 +1,6 @@
 import Loadable, { OptionsWithoutRender } from "react-loadable";
 
-export default <P = any>(loader: () => Promise<any>, options: Partial<OptionsWithoutRender<P>> = {}) => {
+export default <P>(loader: () => Promise<React.ComponentType<P>>, options: Partial<OptionsWithoutRender<P>> = {}) => {
 	return Loadable<P, any>({
 		loader,
 		loading: () => null,

--- a/src/components/auth-buttons/AuthButtons.tsx
+++ b/src/components/auth-buttons/AuthButtons.tsx
@@ -10,7 +10,7 @@ import { add as addError } from "data/errors";
 import { setAccessToken } from "data/user";
 
 @translate("auth-buttons")
-class AuthButtons extends React.Component<AuthButtonsProps, {}> {
+class AuthButtons extends React.Component<AuthButtonsProps> {
 	private validationToken?: string;
 
 	onMessage = (e: MessageEvent) => {

--- a/src/components/balloon/Balloon.tsx
+++ b/src/components/balloon/Balloon.tsx
@@ -4,7 +4,7 @@ import onClickOutside from "react-onclickoutside";
 import style from "./Balloon.scss";
 
 @(onClickOutside as any)
-export class Balloon extends React.PureComponent<BalloonProps, {}> {
+export class Balloon extends React.PureComponent<BalloonProps> {
 	handleClickOutside: () => void;
 
 	constructor(props: BalloonProps) {

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { GridCellProps } from ".";
 import style from "./Grid.scss";
 
-export class Grid extends React.PureComponent<GridProps, {}> {
+export class Grid extends React.PureComponent<GridProps> {
 	render() {
 		const { cell: Cell, gridClass, items, targetColumnWidth, registerLoader } = this.props;
 		return (

--- a/src/components/grid/game-cell/GameCell.tsx
+++ b/src/components/grid/game-cell/GameCell.tsx
@@ -8,7 +8,7 @@ import { GridCellProps } from "..";
 import style from "./GameCell.scss";
 
 @translate("games")
-export class GameCell extends React.PureComponent<GridCellProps<TopGame>, {}> {
+export class GameCell extends React.PureComponent<GridCellProps<TopGame>> {
 	render() {
 		const { item } = this.props;
 

--- a/src/components/grid/stream-cell/StreamCell.tsx
+++ b/src/components/grid/stream-cell/StreamCell.tsx
@@ -8,7 +8,7 @@ import { GridCellProps } from "..";
 import style from "./StreamCell.scss";
 
 @translate("streams")
-export class StreamCell extends React.PureComponent<GridCellProps<Stream>, {}> {
+export class StreamCell extends React.PureComponent<GridCellProps<Stream>> {
 	render() {
 		const { item } = this.props;
 

--- a/src/components/infinite-grid/InfiniteGrid.tsx
+++ b/src/components/infinite-grid/InfiniteGrid.tsx
@@ -4,7 +4,7 @@ import { Grid, GridCellProps } from "components/grid";
 import { InfiniteScroll } from "components/infinite-scroll";
 import { Loading } from "./loading/Loading";
 
-export class InfiniteGrid extends React.PureComponent<InfiniteGridProps, {}> {
+export class InfiniteGrid extends React.PureComponent<InfiniteGridProps> {
 	componentDidMount() {
 		const { initialChunk, items, loadItems } = this.props;
 		if (initialChunk && (!items || items.length <= 0)) {

--- a/src/components/tabs/tab-title/TabTitle.tsx
+++ b/src/components/tabs/tab-title/TabTitle.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import style from "./TabTitle.scss";
 
-export class TabTitle extends React.PureComponent<TabTitleProps, {}> {
+export class TabTitle extends React.PureComponent<TabTitleProps> {
 	render() {
 		const { header, label, activeIndex, index } = this.props;
 		return (

--- a/src/components/tabs/tab/Tab.tsx
+++ b/src/components/tabs/tab/Tab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Helmet from "react-helmet";
 
-export class Tab extends React.PureComponent<TabProps, {}> {
+export class Tab extends React.PureComponent<TabProps> {
 	render() {
 		return (
 			<div>

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -5,7 +5,7 @@ import { InjectedTranslateProps, translate } from "react-i18next";
 import style from "./Auth.scss";
 
 @translate("auth")
-export class Auth extends React.Component<InjectedTranslateProps, {}> {
+export class Auth extends React.Component<InjectedTranslateProps> {
 	componentDidMount() {
 		const query = parse(location.hash.slice(1) || location.search.slice(1));
 		window.opener.postMessage({

--- a/src/pages/directory/Directory.tsx
+++ b/src/pages/directory/Directory.tsx
@@ -4,7 +4,7 @@ import { Route, RouteComponentProps, Switch } from "react-router-dom";
 import Main from "./main/Main";
 import Streams from "./streams/Streams";
 
-export class Directory extends React.PureComponent<RouteComponentProps<{}>, {}> {
+export class Directory extends React.PureComponent<RouteComponentProps<{}>> {
 	render() {
 		const { match } = this.props;
 		return (

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import { NavLink, RouteComponentProps } from "react-router-dom";
 import style from "./Home.scss";
 
 @translate("home")
-export class Home extends React.Component<Props, any> {
+export class Home extends React.Component<Props> {
 	render() {
 		const t = this.props.t!;
 

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -12,7 +12,7 @@ import { themes } from "styles/themes";
 import style from "./Settings.scss";
 
 @translate("settings")
-class Settings extends React.Component<SettingsProps, {}> {
+class Settings extends React.Component<SettingsProps> {
 	onThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
 		this.props.loadTheme(e.target.value);
 	}


### PR DESCRIPTION
I meant to send this PR with the remaining System.import -> dynamic import conversions but you already did them. 

Removing the empty state type parameter from the React components is purely cosmetical but I think it's more expressive if they don't have state anyway.

The `Loadable` type signature change actually results in the correct proptypes being picked up for lazy-loaded components.